### PR TITLE
Update permissions during COPY in Dockerfiles

### DIFF
--- a/finish/name/Dockerfile
+++ b/finish/name/Dockerfile
@@ -1,6 +1,6 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY target/liberty/wlp/usr/servers/defaultServer/server.env /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/name.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/server.env /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/name.war

--- a/finish/ping/Dockerfile
+++ b/finish/ping/Dockerfile
@@ -1,6 +1,6 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY target/liberty/wlp/usr/servers/defaultServer/server.env /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/ping.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/server.env /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/ping.war

--- a/start/name/Dockerfile
+++ b/start/name/Dockerfile
@@ -1,6 +1,6 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY target/liberty/wlp/usr/servers/defaultServer/server.env /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/name.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/server.env /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/name.war

--- a/start/ping/Dockerfile
+++ b/start/ping/Dockerfile
@@ -1,6 +1,6 @@
 FROM open-liberty
 
-COPY target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
-COPY target/liberty/wlp/usr/servers/defaultServer/server.env /config
-COPY src/main/liberty/config/server.xml /config
-COPY target/*.war /config/apps/ping.war
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config
+COPY --chown=1001:0 target/liberty/wlp/usr/servers/defaultServer/server.env /config
+COPY --chown=1001:0 src/main/liberty/config/server.xml /config
+COPY --chown=1001:0 target/*.war /config/apps/ping.war


### PR DESCRIPTION
Since OL images now run as non-root, we have to make sure that all the artifacts being copied into the image have the correct permissions to be read and executed by user 1001 or group 0.