### PR TITLE
Changed page SEO to match title of guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@
 :page-related-guides: ['docker', 'istio']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
 :source-highlighter: prettify
-:page-seo-title: Kubernetes tutorial
+:page-seo-title: Deploying microservices to Kubernetes
 :page-seo-description: How to deploy microservices to Kubernetes and manage your cluster
 :guide-author: Open Liberty
 = Deploying microservices to Kubernetes


### PR DESCRIPTION
Keep the consistency since each guide's page SEO matches the title.