### PR TITLE
Fixing related-guides-section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@
 :page-description: Explore how to deploy microservices to Kubernetes and manage your cluster.
 :page-tags: ['Kubernetes', 'Docker']
 :page-permalink: /guides/{projectid}
-:page-related-guides: ['docker', 'istio']
+:page-related-guides: ['docker', 'istio-intro']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
 :source-highlighter: prettify
 :page-seo-title: Deploying Java microservices to Kubernetes

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 // INSTRUCTION: Please remove all comments that start INSTRUCTION prior to commit. Most comments should be removed, although not the copyright.
 // INSTRUCTION: The copyright statement must appear at the top of the file
 //
-// Copyright (c) 2018, 2019 IBM Corporation and others.
+// Copyright (c) 2018, 2021 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/


### PR DESCRIPTION
At the moment in the related guides section there is only the docker guide. Where as in the raw file it says that there should also be the istio guide. I am guessing that by "istio" it is meant "istio-intro"?