### PR TITLE
Merge qa to master: Cloud hosted guide adjustments (#166)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,20 +52,16 @@ further leveraged for all steps of a continuous delivery pipeline.
 
 === Why use {kube}?
 
-Managing individual containers can be challenging.  A few containers used for development by a small team might not pose a problem,
-but managing hundreds of containers can give even a large team of experienced developers a headache. {kube} is a primary
-tool for deployment in containerized
-environments. It handles scheduling, deployment, as well as mass deletion and creation of containers.
-It provides update rollout abilities on a large scale that would otherwise prove extremely tedious
-to do. Imagine that you updated a Docker image, which now needs to propagate to a dozen containers.
+Managing individual containers can be challenging. 
+A small team can easily manage a few containers for development but 
+managing hundreds of containers can be a headache, even for a large team of experienced developers.
+{kube} is a tool for deployment in containerized environments. 
+It handles scheduling, deployment, as well as mass deletion and creation of containers. 
+It provides update rollout abilities on a large scale that would otherwise prove extremely tedious to do. 
+Imagine that you updated a Docker image, which now needs to propagate to a dozen containers. 
 While you could destroy and then re-create these containers, you can also run a short one-line
 command to have {kube} make all those updates for you. Of course, this is just a simple example.
 {kube} has a lot more to offer.
-
-// {kube} provides much other functionality
-// that simply makes your development, testing, and production environments much more stable, much more
-// automated, and much more powerful to use. Some of this functionality, we're hoping you can learn in
-// this guide.
 
 === Architecture
 
@@ -88,8 +84,8 @@ that define a set of rules by which the pods can be accessed. In a basic scenari
 service exposes a node port that can be used together with the cluster IP address to access
 the pods encapsulated by the service.
 
-To learn about the various Kubernetes resources that you can configure, see the https://kubernetes.io/docs/concepts/[official {kube} documentation^].
-
+To learn about the various Kubernetes resources that you can configure, 
+see the https://kubernetes.io/docs/concepts/[official {kube} documentation^].
 
 // =================================================================================================
 // Introduction
@@ -98,18 +94,16 @@ To learn about the various Kubernetes resources that you can configure, see the 
 == What you'll learn
 
 You will learn how to deploy two microservices in Open Liberty containers to a local {kube} cluster.
-You will then manage your deployed microservices using the `kubectl` command line
-interface for {kube}. The `kubectl` CLI is your primary tool for communicating with and managing your
-{kube} cluster.
+You will then manage your deployed microservices using the `kubectl` command line interface for {kube}. 
+The `kubectl` CLI is your primary tool for communicating with and managing your {kube} cluster.
 
 The two microservices you will deploy are called `system` and `inventory`. The `system` microservice
 returns the JVM system properties of the running container and it returns the pod's name in the HTTP header
 making replicas easy to distinguish from each other. The `inventory` microservice
-adds the properties from the `system` microservice to the inventory. This demonstrates
-how communication can be established between pods inside a cluster.
+adds the properties from the `system` microservice to the inventory. 
+This process demonstrates how communication can be established between pods inside a cluster.
 
 You will use a local single-node {kube} cluster.
-
 
 // =================================================================================================
 // Prerequisites
@@ -125,12 +119,58 @@ include::{common-includes}/gitclone.adoc[]
 
 // no "try what you'll build" section in this guide since it would be too long due to all setup the user will have to do.
 
-
 // =================================================================================================
 // Staring and preparing your cluster for deployment
 // =================================================================================================
+// Static guide instruction
+ifndef::cloud-hosted[]
 [role='command']
 include::{common-includes}/kube-start.adoc[]
+endif::[]
+
+// Cloud hosted guide instructions
+ifdef::cloud-hosted[]
+== Logging into your cluster
+
+For this guide, you will use a container registry on IBM Cloud to deploy to Kubernetes.
+Get the name of your namespace with the following command:
+
+```
+bx cr namespace-list
+```
+{: codeblock}
+
+Look for output that is similar to the following:
+
+```
+Listing namespaces for account 'QuickLabs - IBM Skills Network' in registry 'us.icr.io'...
+
+Namespace
+sn-labs-yourname
+```
+
+Store the namespace name in a variable.
+Use the namespace name that was obtained from the previous command.
+
+```
+NAMESPACE_NAME={namespace_name}
+```
+{: codeblock}
+
+Verify that the variable contains your namespace name:
+
+```
+echo $NAMESPACE_NAME
+```
+{: codeblock}
+
+Log in to the registry with the following command:
+```
+bx cr login
+```
+{: codeblock}
+
+endif::[]
 
 // =================================================================================================
 // Building and containerizing the microservices
@@ -141,12 +181,12 @@ include::{common-includes}/kube-start.adoc[]
 The first step of deploying to {kube} is to build your microservices and containerize them with Docker.
 
 The starting Java project, which you can find in the `start` directory, is a multi-module Maven
-project that's made up of the `system` and `inventory` microservices. Each microservice resides in its own directory,
-`start/system` and `start/inventory`. Each of these directories also contains a Dockerfile, which is necessary
-for building Docker images. If you're unfamiliar with Dockerfiles, check out the
+project that's made up of the `system` and `inventory` microservices. 
+Each microservice resides in its own directory, `start/system` and `start/inventory`. 
+Each of these directories also contains a Dockerfile, which is necessary for building Docker images. 
+If you're unfamiliar with Dockerfiles, check out the
 https://openliberty.io/guides/containerize.html[Containerizing Microservices^] guide,
 which covers Dockerfiles in depth.
-
 
 Navigate to the `start` directory and build the applications by running the following commands:
 [role='command']
@@ -165,15 +205,18 @@ docker build -t inventory:1.0-SNAPSHOT inventory/.
 ```
 
 The `-t` flag in the `docker build` command allows the Docker image to be labeled (tagged) in the `name[:tag]` format.
-The tag for an image describes the specific image version. If the optional `[:tag]` tag is not specified, the `latest` tag is created by default.
+The tag for an image describes the specific image version. 
+If the optional `[:tag]` tag is not specified, the `latest` tag is created by default.
 
-During the build, you'll see various Docker messages describing what images are being downloaded and
-built. When the build finishes, run the following command to list all local Docker images:
+During the build, you'll see various Docker messages describing what images are being downloaded and built. 
+When the build finishes, run the following command to list all local Docker images:
 [role='command']
 ```
 docker images
 ```
 
+// Static guide instruction
+ifndef::cloud-hosted[]
 Verify that the `system:1.0-SNAPSHOT` and `inventory:1.0-SNAPSHOT` images are listed among them, for example:
 
 include::{common-includes}/os-tabs.adoc[]
@@ -230,11 +273,35 @@ k8s.gcr.io/pause-amd64                                           3.0
 ----
 --
 
+If you don't see the `system:1.0-SNAPSHOT` and `inventory:1.0-SNAPSHOT` images, then check the Maven
+build log for any potential errors.
+In addition, if you are using Minikube, make sure your Docker CLI is configured to use Minikube's Docker daemon 
+instead of your host's Docker daemon.
+endif::[]
+
+// Cloud hosted guide instruction
+ifdef::cloud-hosted[]
+Verify that the `system:1.0-SNAPSHOT` and `inventory:1.0-SNAPSHOT` images are listed among them, for example:
+
+```
+REPOSITORY                                TAG                       
+inventory                                 1.0-SNAPSHOT
+system                                    1.0-SNAPSHOT
+openliberty/open-liberty                  kernel-java8-openj9-ubi
+```
 
 If you don't see the `system:1.0-SNAPSHOT` and `inventory:1.0-SNAPSHOT` images, then check the Maven
 build log for any potential errors.
-In addition, if you are using Minikube, make sure your Docker CLI is configured to use Minikube's Docker daemon and not your host's as described in the previous section.
+If the images built without errors, push them to your container registry on IBM Cloud with the following commands:
 
+```
+docker tag inventory:1.0-SNAPSHOT us.icr.io/$NAMESPACE_NAME/inventory:1.0-SNAPSHOT
+docker tag system:1.0-SNAPSHOT us.icr.io/$NAMESPACE_NAME/system:1.0-SNAPSHOT
+docker push us.icr.io/$NAMESPACE_NAME/inventory:1.0-SNAPSHOT
+docker push us.icr.io/$NAMESPACE_NAME/system:1.0-SNAPSHOT
+```
+{: codeblock}
+endif::[]
 
 // =================================================================================================
 // Deploying the microservices
@@ -244,7 +311,9 @@ In addition, if you are using Minikube, make sure your Docker CLI is configured 
 
 Now that your Docker images are built, deploy them using a Kubernetes resource definition.
 
-A Kubernetes resource definition is a yaml file that contains a description of all your deployments, services, or any other resources that you want to deploy. All resources can also be deleted from the cluster by using the same yaml file that you used to deploy them.
+A Kubernetes resource definition is a yaml file that contains a description of all your deployments, services, 
+or any other resources that you want to deploy. 
+All resources can also be deleted from the cluster by using the same yaml file that you used to deploy them.
 
 [role="code_command hotspot", subs="quotes"]
 ----
@@ -258,12 +327,32 @@ kubernetes.yaml
 include::finish/kubernetes.yaml[]
 ----
 
-This file defines four {kube} resources. It defines two deployments and two services. A {kube} deployment is a resource responsible for controlling the creation and management of pods. A service exposes your deployment so that you can make requests to your containers. Three key items to look at when creating the deployments are the [hotspot=labels1 hotspot=labels2 hotspot=labels3 hotspot=labels4]`labels`, [hotspot=image1 hotspot=image2]`image`, and [hotspot=containerPort1 hotspot=containerPort2]`containerPort` fields. The [hotspot=labels1 hotspot=labels2 hotspot=labels3 hotspot=labels4]`labels` is a way for a {kube} service to reference specific deployments. The [hotspot=image1 hotspot=image2]`image` is the name and tag of the Docker image that you want to use for this container. Finally, the [hotspot=containerPort1 hotspot=containerPort2]`containerPort` is the port that your container exposes for purposes of accessing your application.
+This file defines four {kube} resources. It defines two deployments and two services. 
+A {kube} deployment is a resource that controls the creation and management of pods. 
+A service exposes your deployment so that you can make requests to your containers. 
+Three key items to look at when creating the deployments are the [hotspot=labels1 hotspot=labels2 hotspot=labels3 hotspot=labels4]`labels`, 
+[hotspot=image1 hotspot=image2]`image`, and [hotspot=containerPort1 hotspot=containerPort2]`containerPort` fields. 
+The [hotspot=labels1 hotspot=labels2 hotspot=labels3 hotspot=labels4]`labels` is a way for a {kube} service to reference specific deployments. 
+The [hotspot=image1 hotspot=image2]`image` is the name and tag of the Docker image that you want to use for this container. 
+Finally, the [hotspot=containerPort1 hotspot=containerPort2]`containerPort` is the port that your container exposes to access your application.
 For the services, the key point to understand is that they expose your deployments.
-The binding between deployments and services is specified by the use of labels -- in this case the [hotspot=app1 hotspot=app2 hotspot=app3 hotspot=app4 hotspot=app5 hotspot=app6 hotspot=app7 hotspot=app8]`app` label.
+The binding between deployments and services is specified by labels -- in this case the 
+[hotspot=app1 hotspot=app2 hotspot=app3 hotspot=app4 hotspot=app5 hotspot=app6 hotspot=app7 hotspot=app8]`app` label.
 You will also notice the service has a type of [hotspot=NodePort1 hotspot=NodePort2]`NodePort`.
 This means you can access these services from outside of your cluster via a specific port.
-In this case, the ports will be `31000` and `32000`, but it can also be randomized if the [hotspot=nodePort1 hotspot=nodePort2]`nodePort` field is not used.
+In this case, the ports are `31000` and `32000`, but port numbers can also be randomized if the
+[hotspot=nodePort1 hotspot=nodePort2]`nodePort` field is not used.
+
+// Cloud hosted guide instruction
+ifdef::cloud-hosted[]
+Update the image names so that the images in your IBM Cloud container registry are used:
+
+```
+sed -i 's=system:1.0-SNAPSHOT=us.icr.io/'"$NAMESPACE_NAME"'/system:1.0-SNAPSHOT=g' kubernetes.yaml
+sed -i 's=inventory:1.0-SNAPSHOT=us.icr.io/'"$NAMESPACE_NAME"'/inventory:1.0-SNAPSHOT=g' kubernetes.yaml
+```
+{: codeblock}
+endif::[]
 
 Run the following commands to deploy the resources as defined in kubernetes.yaml:
 [role='command']
@@ -295,6 +384,8 @@ kubectl describe pods
 You can also issue the `kubectl get` and `kubectl describe` commands on other {kube} resources, so feel
 free to inspect all other resources.
 
+// Static guide instruction
+ifndef::cloud-hosted[]
 Next you will make requests to your services.
 
 include::{common-includes}/os-tabs.adoc[]
@@ -309,16 +400,83 @@ The default host name for Docker Desktop is `localhost`.
 The default host name for minikube is {minikube-ip}. Otherwise it can be found using the `minikube ip` command.
 --
 
-Then `curl` or visit the following URLs to access your microservices, substituting the appropriate host name:
+Then, run the `curl` command or visit the following URLs to access your microservices, substituting the appropriate host name:
 
-- `{system-api}`
-- `{inventory-api}/system-service`
+* `{system-api}`
+* `{inventory-api}/system-service`
 
 The first URL returns system properties and the name of the pod in an HTTP header called `X-Pod-Name`.
 To view the header, you may use the `-I` option in the `curl` when making a request to `{system-api}`.
-The second URL adds properties from `system-service` to the inventory
-{kube} Service. Visiting `{inventory-api}/[kube-service]` in general adds to the inventory
-depending on whether `kube-service` is a valid {kube} Service that can be accessed.
+The second URL adds properties from the `system-service` endpoint to the inventory {kube} Service. 
+Visiting `{inventory-api}/[kube-service]` in general adds to the inventory
+depending on whether `kube-service` is a valid {kube} service that can be accessed.
+endif::[]
+
+// Cloud-hosted guide instruction
+ifdef::cloud-hosted[]
+Run the following command to get the node IP for the `system` service:
+
+```
+kubectl describe pod system | grep Node
+```
+{: codeblock}
+
+The output shows the node IP that is later used to access the service. 
+It appears in a format similar to the following:
+
+```
+Node:         10.114.85.140/10.114.85.140
+Node-Selectors:  <none>
+```
+
+The IP for the system service is `10.114.85.140`.
+Store the IP in a variable.
+
+```
+SYSTEM_HOST={system-node-ip}
+```
+{: codeblock}
+
+Use another `kubectl` command to get the node IP for the `inventory` service:
+
+```
+kubectl describe pod inventory | grep Node
+```
+{: codeblock}
+
+Store this IP in a variable as well.
+
+```
+INVENTORY_HOST={inventory-node-ip}
+```
+{: codeblock}
+
+Verify that the variables that contain the IPs are set correctly:
+
+```
+echo $SYSTEM_HOST && echo $INVENTORY_HOST
+```
+{: codeblock}
+
+Then use the following `curl` commands to access your microservices:
+
+```
+curl http://$SYSTEM_HOST:31000/system/properties
+```
+{: codeblock}
+
+```
+curl http://$INVENTORY_HOST:32000/inventory/systems/system-service
+```
+{: codeblock}
+
+The first URL returns system properties and the name of the pod in an HTTP header called `X-Pod-Name`.
+To view the header, you can use the `-I` option in the `curl` command when you make a request to the
+`http://$SYSTEM_HOST:31000/system/properties` URL.
+The second URL adds properties from `system-service` to the inventory {kube} Service. 
+Making a request to the `http://$INVENTORY_HOST:32000/inventory/systems/[kube-service]` URL in general 
+adds to the inventory depending on whether `kube-service` is a valid {kube} service that can be accessed.
+endif::[]
 
 // =================================================================================================
 // Scaling a deployment
@@ -326,7 +484,10 @@ depending on whether `kube-service` is a valid {kube} Service that can be access
 
 == Scaling a deployment
 
-To use load balancing, you need to scale your deployments. When you scale a deployment, you replicate its pods, creating more running instances of your applications. Scaling is one of the primary advantages of {kube} because replicating your application allows it to accommodate more traffic, and then descale your deployments to free up resources when the traffic decreases.
+To use load balancing, you need to scale your deployments. 
+When you scale a deployment, you replicate its pods, creating more running instances of your applications. 
+Scaling is one of the primary advantages of {kube} because you can replicate your application to accommodate more traffic, 
+and then descale your deployments to free up resources when the traffic decreases.
 
 As an example, scale the `system` deployment to three pods by running the following command:
 [role='command']
@@ -349,19 +510,70 @@ system-deployment-6bd97d9bf6-x4zth      1/1       Running   0          25s
 inventory-deployment-645767664f-nbtd9   1/1       Running   0          1m
 ----
 
-Wait for your two new pods to be in the ready state, then `curl -I` or visit the `{system-api}` URL. You'll notice that the `X-Pod-Name` header will have a different value when you call it multiple times. This is because there are now three pods running all serving the `system` application. Similarly, to descale your deployments you can use the same scale command with fewer replicas.
+// Static guide instruction
+ifndef::cloud-hosted[]
+Wait for your two new pods to be in the ready state, then make a `curl -I` request to, or visit the `{system-api}` URL. 
+endif::[]
+
+// Cloud-hosted guide instruction
+ifdef::cloud-hosted[]
+Wait for your two new pods to be in the ready state, then make the following `curl` command:
+
+```
+curl -I http://$SYSTEM_HOST:31000/system/properties
+```
+{: codeblock}
+endif::[]
+
+Notice that the `X-Pod-Name` header has a different value when you call it multiple times.
+The value changes because three pods that all serve the `system` application are now running.
+Similarly, to descale your deployments you can use the same scale command with fewer replicas.
+
+[role='command']
+```
+kubectl scale deployment/system-deployment --replicas=1
+```
 
 == Redeploy microservices
 
-When you're building your application, you may find that you want to quickly test a change. To do that, you can rebuild your Docker images then delete and re-create your {kube} resources. Note that there will only be one `system` pod after you redeploy since you're deleting all of the existing pods.
+When you're building your application, you might want to quickly test a change. 
+To run a quick test, you can rebuild your Docker images then delete and re-create your {kube} resources. 
+Note that there is only one `system` pod after you redeploy since you're deleting all of the existing pods.
+
+// Static guide instruction
+ifndef::cloud-hosted[]
 [role='command']
 ```
 mvn clean package
+docker build -t system:1.0-SNAPSHOT system/.
+docker build -t inventory:1.0-SNAPSHOT inventory/.
+
 kubectl delete -f kubernetes.yaml
 kubectl apply -f kubernetes.yaml
 ```
+endif::[]
 
-This is not how you would want to update your applications when running in production, but in a development environment this is fine. If you want to deploy an updated image to a production cluster, you can update the container in your deployment with a new image. Then, {kube} will automate the creation of a new container and decommissioning of the old one once the new container is ready.
+// Cloud-hosted guide instruction
+ifdef::cloud-hosted[]
+```
+mvn clean package
+docker build -t system:1.0-SNAPSHOT system/.
+docker build -t inventory:1.0-SNAPSHOT inventory/.
+docker tag inventory:1.0-SNAPSHOT us.icr.io/$NAMESPACE_NAME/inventory:1.0-SNAPSHOT
+docker tag system:1.0-SNAPSHOT us.icr.io/$NAMESPACE_NAME/system:1.0-SNAPSHOT
+docker push us.icr.io/$NAMESPACE_NAME/inventory:1.0-SNAPSHOT
+docker push us.icr.io/$NAMESPACE_NAME/system:1.0-SNAPSHOT
+
+kubectl delete -f kubernetes.yaml
+kubectl apply -f kubernetes.yaml
+```
+{: codeblock}
+endif::[]
+
+Updating your applications in this way is fine for development environments, but it is not suitable for production.
+If you want to deploy an updated image to a production cluster, 
+you can update the container in your deployment with a new image. 
+Once the new container is ready, {kube} automates both the creation of a new container and the decommissioning of the old one.
 
 // =================================================================================================
 // Testing microservices that are running on {kube}
@@ -374,9 +586,10 @@ pom.xml
 include::finish/inventory/pom.xml[]
 ----
 
-A few tests are included for you to test the basic functionality of the microservices. If a test failure
-occurs, then you might have introduced a bug into the code. To run the tests, wait for all pods to be
-in the ready state before proceeding further. The default properties defined in the [hotspot]`pom.xml` are:
+A few tests are included for you to test the basic functionality of the microservices. 
+If a test failure occurs, then you might have introduced a bug into the code. 
+To run the tests, wait for all pods to be in the ready state before proceeding further. 
+The default properties defined in the [hotspot]`pom.xml` are:
 
 [cols="15, 100", options="header"]
 |===
@@ -389,11 +602,12 @@ in the ready state before proceeding further. The default properties defined in 
 
 Navigate back to the `start` directory.
 
+// Static guide instruction
+ifndef::cloud-hosted[]
 include::{common-includes}/os-tabs.adoc[]
 
 [.tab_content.windows_section.mac_section]
 --
-
 Run the integration tests against a cluster running with a host name of `localhost`:
 [role='command']
 ```
@@ -409,6 +623,25 @@ Run the integration tests with the IP address for Minikube:
 mvn failsafe:integration-test -Dcluster.ip=$(minikube ip)
 ```
 --
+endif::[]
+
+// Cloud-hosted guide instruction
+ifdef::cloud-hosted[]
+Update the `pom.xml` files so that the `cluster.ip` properties match the values of your node IPs.
+
+```
+sed -i 's=localhost='"$INVENTORY_HOST"'=g' inventory/pom.xml
+sed -i 's=localhost='"$SYSTEM_HOST"'=g' system/pom.xml
+```
+{: codeblock}
+
+Run the integration tests by using the following command:
+
+```
+mvn failsafe:integration-test
+```
+{: codeblock}
+endif::[]
 
 If the tests pass, you'll see an output similar to the following for each service respectively:
 
@@ -438,22 +671,24 @@ Results:
 Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
 ----
 
-
 // =================================================================================================
 // Tear Down
 // =================================================================================================
 
 == Tearing down the environment
 
-When you no longer need your deployed microservices, you can delete all {kube} resources by running the `kubectl delete` command:
+When you no longer need your deployed microservices, 
+you can delete all {kube} resources by running the `kubectl delete` command:
 [role='command']
 ```
 kubectl delete -f kubernetes.yaml
 ```
 
+// Static guide only instruction
+ifndef::cloud-hosted[]
 [role='command']
 include::{common-includes}/kube-minikube-teardown.adoc[]
-
+endif::[]
 
 // =================================================================================================
 // finish
@@ -461,7 +696,8 @@ include::{common-includes}/kube-minikube-teardown.adoc[]
 
 == Great work! You're done!
 
-You have just deployed two microservices running in Open Liberty to {kube}. You then scaled a microservice and ran integration tests against miroservices that are running in a {kube} cluster.
+You have just deployed two microservices that are running in Open Liberty to {kube}.
+You then scaled a microservice and ran integration tests against miroservices that are running in a {kube} cluster.
 
 // Include the below from the guides-common repo to tell users how they can contribute to the guide
 


### PR DESCRIPTION
* Style adjustments

* Style adjustments

* Line length adjustments for readability

* Add login command specific to cloud hosted guides

* Commands regarding images

* Commands to access service

* Rewordings

* Adjustments for testing

* Fixes to tags for cloud-hosted or not

* Update README.adoc

* Update README.adoc

* Change descale command

* command fixes

* Adjust Docker image build section

* Address ID review

Co-authored-by: Gilbert Kwan <gkwan@ca.ibm.com>
Co-authored-by: Austin Seto <austin.seto@ibm.com>