### PR TITLE
Merge staging to prod - Update README.adoc (#190)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -451,7 +451,7 @@ localhost:8001/api/v1/namespaces/sn-labs-yourname/services/inventory-service/pro
 Then, use the following **curl** command to access your **system** microservice:
 
 ```
-curl -s ttp://$SYSTEM_PROXY/system/properties | jq
+curl -s http://$SYSTEM_PROXY/system/properties | jq
 ```
 {: codeblock}
 


### PR DESCRIPTION
There is a `curl -s ttp:/...` that missing an h character